### PR TITLE
feat: Add event type commands

### DIFF
--- a/rowifi/src/commands/events/mod.rs
+++ b/rowifi/src/commands/events/mod.rs
@@ -1,5 +1,7 @@
 mod new;
+mod types;
 mod view;
 
 pub use new::new_event;
+pub use types::{new_event_type, view_event_types};
 pub use view::{view_attendee_events, view_event, view_host_events};

--- a/rowifi/src/commands/events/types/mod.rs
+++ b/rowifi/src/commands/events/types/mod.rs
@@ -1,0 +1,84 @@
+mod new;
+
+use itertools::Itertools;
+use rowifi_framework::{prelude::*, utils::paginate_embeds};
+use rowifi_models::{
+    discord::{
+        http::interaction::{InteractionResponse, InteractionResponseType},
+        util::Timestamp,
+    },
+    guild::GuildType,
+};
+use std::sync::Arc;
+use twilight_standby::Standby;
+
+pub use new::new_event_type;
+
+pub async fn view_event_types(
+    bot: Extension<BotContext>,
+    standby: Extension<Arc<Standby>>,
+    command: Command<()>,
+) -> impl IntoResponse {
+    tokio::spawn(async move {
+        if let Err(err) = view_event_types_func(&bot, standby.0, &command.ctx).await {
+            handle_error(bot.0, command.ctx, err).await;
+        }
+    });
+
+    Json(InteractionResponse {
+        kind: InteractionResponseType::DeferredChannelMessageWithSource,
+        data: None,
+    })
+}
+
+pub async fn view_event_types_func(
+    bot: &BotContext,
+    standby: Arc<Standby>,
+    ctx: &CommandContext,
+) -> CommandResult {
+    let guild = bot
+        .get_guild(
+            "SELECT guild_id, kind, event_types FROM guilds WHERE guild_id = $1",
+            ctx.guild_id,
+        )
+        .await?;
+
+    // Check for Gamma Tier
+    let kind = guild.kind.unwrap_or_default();
+    if kind != GuildType::Gamma {
+        let message = "The Events module is only available for Gamma Tier servers. You can upgrade the server on the dashboard.";
+        ctx.respond(&bot).content(message).unwrap().await?;
+        return Ok(());
+    }
+
+    if guild.event_types.is_empty() {
+        let message = r"
+This server has no event types configured. Looking to add one? Use the command `/event-types new`.
+        ";
+        ctx.respond(&bot).content(message).unwrap().await?;
+        return Ok(());
+    }
+
+    let mut pages = Vec::new();
+    let mut page_count = 0usize;
+    let event_types = guild.event_types;
+    for ets in &event_types.into_iter().chunks(12) {
+        let mut embed = EmbedBuilder::new()
+            .color(DARK_GREEN)
+            .footer(EmbedFooterBuilder::new("RoWifi").build())
+            .timestamp(Timestamp::from_secs(Utc::now().timestamp()).unwrap())
+            .title("Event Types")
+            .description(format!("Page {}", page_count + 1));
+        for et in ets {
+            let name = format!("ID: {}", et.id);
+            let desc = format!("Name: {}\n Disabled: {}", et.name, et.disabled);
+            embed = embed.field(EmbedFieldBuilder::new(name, desc).inline().build());
+        }
+        pages.push(embed.build());
+        page_count += 1;
+    }
+
+    paginate_embeds(&ctx, &bot, &standby, pages, page_count).await?;
+
+    Ok(())
+}

--- a/rowifi/src/commands/events/types/new.rs
+++ b/rowifi/src/commands/events/types/new.rs
@@ -1,0 +1,107 @@
+use rowifi_core::events::types::add::{add_event_type, AddEventTypeError, EventTypeArguments};
+use rowifi_framework::prelude::*;
+use rowifi_models::{
+    discord::{
+        http::interaction::{InteractionResponse, InteractionResponseType},
+        util::Timestamp,
+    },
+    guild::GuildType,
+};
+
+#[derive(Arguments, Debug)]
+pub struct AddEventTypeArguments {
+    pub id: u32,
+    pub name: String,
+}
+
+pub async fn new_event_type(
+    bot: Extension<BotContext>,
+    command: Command<AddEventTypeArguments>,
+) -> impl IntoResponse {
+    tokio::spawn(async move {
+        if let Err(err) = new_event_type_func(&bot, &command.ctx, command.args).await {
+            handle_error(bot.0, command.ctx, err).await;
+        }
+    });
+
+    Json(InteractionResponse {
+        kind: InteractionResponseType::DeferredChannelMessageWithSource,
+        data: None,
+    })
+}
+
+pub async fn new_event_type_func(
+    bot: &BotContext,
+    ctx: &CommandContext,
+    args: AddEventTypeArguments,
+) -> CommandResult {
+    let guild = bot
+        .get_guild(
+            "SELECT guild_id, kind, event_types FROM guilds WHERE guild_id = $1",
+            ctx.guild_id,
+        )
+        .await?;
+
+    // Check for Gamma Tier
+    let kind = guild.kind.unwrap_or_default();
+    if kind != GuildType::Gamma {
+        let message = "The Events module is only available for Gamma Tier servers. You can upgrade the server on the dashboard.";
+        ctx.respond(&bot).content(message).unwrap().await?;
+        return Ok(());
+    }
+
+    let res = match add_event_type(
+        &bot.database,
+        ctx.guild_id,
+        ctx.author_id,
+        guild.event_types,
+        EventTypeArguments {
+            id: args.id,
+            name: args.name,
+        },
+    )
+    .await
+    {
+        Ok(e) => e,
+        Err(AddEventTypeError::IdAlreadyExists) => {
+            let message = format!(
+                r#"
+    An Event Type with ID {} already exists.
+            "#,
+                args.id
+            );
+            ctx.respond(&bot).content(&message).unwrap().await?;
+            return Ok(());
+        }
+        Err(AddEventTypeError::Generic(err)) => return Err(err),
+    };
+
+    let embed = EmbedBuilder::new()
+        .color(DARK_GREEN)
+        .footer(EmbedFooterBuilder::new("RoWifi").build())
+        .timestamp(Timestamp::from_secs(Utc::now().timestamp()).unwrap())
+        .title("Event Type Creation Successful")
+        .build();
+    ctx.respond(&bot).embeds(&[embed]).unwrap().await?;
+
+    if let Some(log_channel) = guild.log_channel {
+        let embed = EmbedBuilder::new()
+            .color(BLUE)
+            .footer(EmbedFooterBuilder::new("RoWifi").build())
+            .timestamp(Timestamp::from_secs(Utc::now().timestamp()).unwrap())
+            .title(format!("Action by <@{}>", ctx.author_id))
+            .description("Event Type added")
+            .field(EmbedFieldBuilder::new(
+                format!("**Id: {}**\n", res.event.id),
+                format!("Name: {}", res.event.name),
+            ))
+            .build();
+        let _ = bot
+            .http
+            .create_message(log_channel.0)
+            .embeds(&[embed])
+            .await;
+    }
+
+    Ok(())
+}

--- a/rowifi/src/main.rs
+++ b/rowifi/src/main.rs
@@ -46,7 +46,7 @@ use crate::commands::{
     denylists::{
         add_custom_denylist, add_group_denylist, add_user_denylist, delete_denylist, view_denylists,
     },
-    events::{new_event, view_attendee_events, view_event, view_host_events},
+    events::{new_event, view_attendee_events, view_event, view_host_events, new_event_type, view_event_types},
     groupbinds::{delete_groupbind, new_groupbind, view_groupbinds},
     rankbinds::{delete_rankbind, new_rankbind, view_rankbinds},
     server::{serverinfo, update_all, update_role},
@@ -132,6 +132,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .route("/event/attendee", post(view_attendee_events))
         .route("/event/host", post(view_host_events))
         .route("/event/view", post(view_event))
+        .route("/event-types/new", post(new_event_type))
+        .route("/event-types/view", post(view_event_types))
         .route("/backup/new", post(backup_new))
         .route("/backup/restore", post(backup_restore))
         .route("/backup/view", post(backup_view))

--- a/rowifi_core/src/events/mod.rs
+++ b/rowifi_core/src/events/mod.rs
@@ -1,1 +1,2 @@
 pub mod new;
+pub mod types;

--- a/rowifi_core/src/events/types/add.rs
+++ b/rowifi_core/src/events/types/add.rs
@@ -1,0 +1,98 @@
+use chrono::Utc;
+use rowifi_database::{postgres::types::Json, Database};
+use rowifi_models::{
+    audit_log::{AuditLog, AuditLogData, AuditLogKind},
+    events::EventType,
+    id::{GuildId, UserId},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::RoError;
+
+#[derive(Debug, Serialize)]
+pub struct AddEventType {
+    pub event: EventType,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventTypeArguments {
+    pub id: u32,
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub enum AddEventTypeError {
+    IdAlreadyExists,
+    Generic(RoError),
+}
+
+/// Adds an event type to the server.
+///
+/// # Errors
+///
+/// See [`RoError`] for details.
+pub async fn add_event_type(
+    database: &Database,
+    guild_id: GuildId,
+    author_id: UserId,
+    mut existing_event_types: Vec<EventType>,
+    args: EventTypeArguments,
+) -> Result<AddEventType, AddEventTypeError> {
+    if existing_event_types
+        .iter()
+        .find(|e| e.id == args.id)
+        .is_some()
+    {
+        return Err(AddEventTypeError::IdAlreadyExists);
+    }
+
+    let new_event_type = EventType {
+        id: args.id,
+        name: args.name,
+        disabled: false,
+    };
+    existing_event_types.push(new_event_type.clone());
+
+    database
+        .execute(
+            "UPDATE guilds SET event_types = $2 WHERE guild_id = $1",
+            &[&guild_id, &Json(existing_event_types)],
+        )
+        .await
+        .map_err(RoError::from)?;
+
+    let log = AuditLog {
+        kind: AuditLogKind::EventTypeCreate,
+        guild_id: Some(guild_id),
+        user_id: Some(author_id),
+        timestamp: Utc::now(),
+        metadata: AuditLogData::EventTypeCreate {
+            id: args.id,
+        },
+    };
+
+    database
+        .execute(
+            r"INSERT INTO audit_logs(kind, guild_id, user_id, timestamp, metadata) 
+        VALUES($1, $2, $3, $4, $5)",
+            &[
+                &log.kind,
+                &log.guild_id,
+                &log.user_id,
+                &log.timestamp,
+                &Json(log.metadata),
+            ],
+        )
+        .await
+        .map_err(RoError::from)?;
+
+    Ok(AddEventType {
+        event: new_event_type,
+    })
+}
+
+impl From<RoError> for AddEventTypeError {
+    fn from(err: RoError) -> Self {
+        Self::Generic(err)
+    }
+}

--- a/rowifi_core/src/events/types/mod.rs
+++ b/rowifi_core/src/events/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod add;

--- a/rowifi_models/src/audit_log.rs
+++ b/rowifi_models/src/audit_log.rs
@@ -36,8 +36,7 @@ pub enum AuditLogKind {
     EventLog = 10,
     SettingModify = 11,
     EventTypeCreate = 12,
-    EventTypeDelete = 13,
-    EventTypeModify = 14,
+    EventTypeModify = 13,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -87,15 +86,12 @@ pub enum AuditLogData {
     },
     EventTypeCreate {
         id: u32,
-        name: String,
     },
     EventTypeDelete {
         id: u32,
-        name: String,
     },
     EventTypeModify {
         id: u32,
-        name: String,
     },
 }
 


### PR DESCRIPTION
Adds the `/event-types new` and `/event-types view`.

It is not possible to delete event types.

The dashboard will handle the disabling/enabling event types.