### PR TITLE
bug: fix error deserializing when member count is negative

### DIFF
--- a/rowifi_models/src/roblox/group.rs
+++ b/rowifi_models/src/roblox/group.rs
@@ -7,7 +7,7 @@ pub struct PartialGroup {
     pub id: GroupId,
     pub name: String,
     #[serde(rename = "memberCount")]
-    pub member_count: u64,
+    pub member_count: i64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17,7 +17,7 @@ pub struct PartialRank {
     pub name: Option<String>,
     pub rank: u32,
     #[serde(rename = "memberCount")]
-    pub member_count: Option<u64>,
+    pub member_count: Option<i64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -40,5 +40,5 @@ pub struct GroupRole {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "memberCount")]
-    pub member_count: Option<u64>,
+    pub member_count: Option<i64>,
 }


### PR DESCRIPTION
While this is not ideal, it's a simple bandaid. Since the field is not used in bind creation, it's fine to accept negative member counts