### PR TITLE
fix: Ensure groupbinds are processed in debug update when nickname_bnd is None

### DIFF
--- a/rowifi/src/commands/user/update/debug.rs
+++ b/rowifi/src/commands/user/update/debug.rs
@@ -295,11 +295,9 @@ pub async fn debug_update_func(
                 if highest.priority() < groupbind.priority {
                     nickname_bind = Some(Bind::Group(groupbind.clone()));
                 }
-            } else { // This is the new else block
+            } else {
                 nickname_bind = Some(Bind::Group(groupbind.clone()));
             }
-            // Ensure these lines are outside the `if let Some(ref highest)` block,
-            // but still inside `if user_ranks.contains_key(...)`
             roles_to_add.extend(groupbind.discord_roles.iter().copied());
             for role in &groupbind.discord_roles {
                 if !role_addition_tracking.contains_key(role) {

--- a/rowifi/src/commands/user/update/debug.rs
+++ b/rowifi/src/commands/user/update/debug.rs
@@ -295,11 +295,15 @@ pub async fn debug_update_func(
                 if highest.priority() < groupbind.priority {
                     nickname_bind = Some(Bind::Group(groupbind.clone()));
                 }
-                roles_to_add.extend(groupbind.discord_roles.iter().copied());
-                for role in &groupbind.discord_roles {
-                    if !role_addition_tracking.contains_key(role) {
-                        role_addition_tracking.insert(*role, BindRef::Group(groupbind));
-                    }
+            } else { // This is the new else block
+                nickname_bind = Some(Bind::Group(groupbind.clone()));
+            }
+            // Ensure these lines are outside the `if let Some(ref highest)` block,
+            // but still inside `if user_ranks.contains_key(...)`
+            roles_to_add.extend(groupbind.discord_roles.iter().copied());
+            for role in &groupbind.discord_roles {
+                if !role_addition_tracking.contains_key(role) {
+                    role_addition_tracking.insert(*role, BindRef::Group(groupbind));
                 }
             }
         }


### PR DESCRIPTION
The logic for processing groupbinds did not correctly handle the case where `nickname_bind` was `None` prior to evaluating groupbinds. If `nickname_bind` was `None`, it would not be set by an applicable groupbind, and the associated roles would not be added to `roles_to_add`.